### PR TITLE
Translate instructors names

### DIFF
--- a/index.md
+++ b/index.md
@@ -14,7 +14,7 @@ humantime: "10:00 - 12:00"    # human-readable times for the workshop (e.g., "9:
 startdate: 2021-04-02      # machine-readable start date for the workshop in YYYY-MM-DD format like 2015-01-01
 enddate: 2021-04-06        # machine-readable end date for the workshop in YYYY-MM-DD format like 2015-01-02
 instructor: ["ニッタ ジョエル", "武井 陸良"] # boxed, comma-separated list of instructors' names as strings, like ["Kay McNulty", "Betty Jennings", "Betty Snyder"]
-helper: [ "ケリー トム", "西田 孝三", "山口 雅美", "Satoshi Yokota"]     # boxed, comma-separated list of helpers' names, like ["Marlyn Wescoff", "Fran Bilas", "Ruth Lichterman"]
+helper: [ "ケリー トム", "西田 孝三", "山口 雅美"]     # boxed, comma-separated list of helpers' names, like ["Marlyn Wescoff", "Fran Bilas", "Ruth Lichterman"]
 email: ["nitta@bs.s.u-tokyo.ac.jp"]    # boxed, comma-separated list of contact email addresses for the host, lead instructor, or whoever else is handling questions, like ["marlyn.wescoff@example.org", "fran.bilas@example.org", "ruth.lichterman@example.org"]
 collaborative_notes: https://docs.google.com/document/d/1G11-8sXl5hbb71ky-YmeHpDvPWXkp0Y-Q65V-59-z78/edit?usp=sharing # optional: URL for the workshop collaborative notes, e.g. an Etherpad or Google Docs document (e.g., https://pad.carpentries.org/2015-01-01-euphoria)
 eventbrite:           # optional: alphanumeric key for Eventbrite registration, e.g., "1234567890AB" (if Eventbrite is being used)

--- a/index.md
+++ b/index.md
@@ -13,8 +13,8 @@ humandate: "2021年 4月2日, 7日, 9日, 14日, 16日"    # human-readable date
 humantime: "10:00 - 12:00"    # human-readable times for the workshop (e.g., "9:00 am - 4:30 pm")
 startdate: 2021-04-02      # machine-readable start date for the workshop in YYYY-MM-DD format like 2015-01-01
 enddate: 2021-04-06        # machine-readable end date for the workshop in YYYY-MM-DD format like 2015-01-02
-instructor: ["ニッタ ジョエル", "Riku Takei"] # boxed, comma-separated list of instructors' names as strings, like ["Kay McNulty", "Betty Jennings", "Betty Snyder"]
-helper: [ "Tom Kelly", "Kozo Nishida", "Masami Yamaguchi", "Satoshi Yokota"]     # boxed, comma-separated list of helpers' names, like ["Marlyn Wescoff", "Fran Bilas", "Ruth Lichterman"]
+instructor: ["ニッタ ジョエル", "武井 陸良"] # boxed, comma-separated list of instructors' names as strings, like ["Kay McNulty", "Betty Jennings", "Betty Snyder"]
+helper: [ "ケリー トム", "西田 孝三", "Masami Yamaguchi", "Satoshi Yokota"]     # boxed, comma-separated list of helpers' names, like ["Marlyn Wescoff", "Fran Bilas", "Ruth Lichterman"]
 email: ["nitta@bs.s.u-tokyo.ac.jp"]    # boxed, comma-separated list of contact email addresses for the host, lead instructor, or whoever else is handling questions, like ["marlyn.wescoff@example.org", "fran.bilas@example.org", "ruth.lichterman@example.org"]
 collaborative_notes: https://docs.google.com/document/d/1G11-8sXl5hbb71ky-YmeHpDvPWXkp0Y-Q65V-59-z78/edit?usp=sharing # optional: URL for the workshop collaborative notes, e.g. an Etherpad or Google Docs document (e.g., https://pad.carpentries.org/2015-01-01-euphoria)
 eventbrite:           # optional: alphanumeric key for Eventbrite registration, e.g., "1234567890AB" (if Eventbrite is being used)

--- a/index.md
+++ b/index.md
@@ -14,7 +14,7 @@ humantime: "10:00 - 12:00"    # human-readable times for the workshop (e.g., "9:
 startdate: 2021-04-02      # machine-readable start date for the workshop in YYYY-MM-DD format like 2015-01-01
 enddate: 2021-04-06        # machine-readable end date for the workshop in YYYY-MM-DD format like 2015-01-02
 instructor: ["ニッタ ジョエル", "武井 陸良"] # boxed, comma-separated list of instructors' names as strings, like ["Kay McNulty", "Betty Jennings", "Betty Snyder"]
-helper: [ "ケリー トム", "西田 孝三", "Masami Yamaguchi", "Satoshi Yokota"]     # boxed, comma-separated list of helpers' names, like ["Marlyn Wescoff", "Fran Bilas", "Ruth Lichterman"]
+helper: [ "ケリー トム", "西田 孝三", "山口 雅美", "Satoshi Yokota"]     # boxed, comma-separated list of helpers' names, like ["Marlyn Wescoff", "Fran Bilas", "Ruth Lichterman"]
 email: ["nitta@bs.s.u-tokyo.ac.jp"]    # boxed, comma-separated list of contact email addresses for the host, lead instructor, or whoever else is handling questions, like ["marlyn.wescoff@example.org", "fran.bilas@example.org", "ruth.lichterman@example.org"]
 collaborative_notes: https://docs.google.com/document/d/1G11-8sXl5hbb71ky-YmeHpDvPWXkp0Y-Q65V-59-z78/edit?usp=sharing # optional: URL for the workshop collaborative notes, e.g. an Etherpad or Google Docs document (e.g., https://pad.carpentries.org/2015-01-01-euphoria)
 eventbrite:           # optional: alphanumeric key for Eventbrite registration, e.g., "1234567890AB" (if Eventbrite is being used)


### PR DESCRIPTION
@rikutakei @kozo2 let me know if you prefer names written differently.

I publish as "S. Thomas Kelly" (ケリー・サイモン・トーマス) but [previous workshops](https://mikblack.github.io/2016-06-29-Otago) use ["Tom Kelly"](https://mikblack.github.io/2016-06-29-Otago) (ケリートム) so I'm okay being consistent with that. AMY links to GitHub profiles so it's not a problem.