### PR TITLE
migrate CoC and License from translated R lessons

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,11 +1,12 @@
 ---
 layout: page
-title: "Contributor Code of Conduct"
+title: "投稿者の行動規範"
 ---
-As contributors and maintainers of this project,
-we pledge to follow the [Carpentry Code of Conduct][coc].
+プロジェクト貢献者・保持者は、
+[カーペントリーの行動規範][coc]に基づき行動することを誓います。
 
-Instances of abusive, harassing, or otherwise unacceptable behavior
-may be reported by following our [reporting guidelines][coc-reporting].
+嫌がらせ、ハラスメント行為、その他の悪意ある行動・言動は、
+カーペントリーの[報告ガイドライン][coc-reporting]に沿って報告させていただきます。
 
 {% include links.md %}
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,142 +1,153 @@
-# Contributing
+# プロジェクトに貢献する
 
-[Software Carpentry][swc-site] and [Data Carpentry][dc-site] are open source projects,
-and we welcome contributions of all kinds:
-new lessons,
-fixes to existing material,
-bug reports,
-and reviews of proposed changes are all welcome.
+[SoftwareCarpentry][swc-site]と[DataCarpentry][dc-site]はオープンソースのプロジェクトです。
+コミュニティーからの資料提供・ご協力、例えば、
+新しいレッスン、
+既存の資料の修正、
+バグレポート、
+変更点のレビューなど、どんなに些細な変更も歓迎いたします。
 
-## Contributor Agreement
+## 貢献する方法
 
-By contributing,
-you agree that we may redistribute your work under [our license](LICENSE.md).
-In exchange,
-we will address your issues and/or assess your change proposal as promptly as we can,
-and help you become a member of our community.
-Everyone involved in [Software Carpentry][swc-site] and [Data Carpentry][dc-site]
-agrees to abide by our [code of conduct](CONDUCT.md).
+このプロジェクトに貢献することにより、
+自身が提供したコンテンツを[私達のライセンス](License.md)に基づき配布する事に同意するものとします。
+ご協力と引き換えに、
+私達はあなたが提供する変更点・問題点などを検討し、
+できるだけ早くコミュニティーの一員になれるよう尽力いたします。
+[Software Carpentry][swc-site]と[Data Carpentry][dc-site]の一員になられた際には、
+私達の[行動規範](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html)を遵守する事に同意していただきます。
 
-## How to Contribute
+## 貢献する方法
 
-The easiest way to get started is to file an issue
-to tell us about a spelling mistake,
-some awkward wording,
-or a factual error.
-This is a good way to introduce yourself
-and to meet some of our community members.
+一番簡単に貢献する方法は、
+誤字、言葉遣い、
+間違った内容などを
+issue(イシュー)で報告する事です。
+Issueを報告することによって、自分をコミュニティーに紹介し、
+また、コミュニティーのメンバーと出会う良い機会にもなります。
 
-1.  If you do not have a [GitHub][github] account,
-    you can [send us comments by email][contact].
-    However,
-    we will be able to respond more quickly if you use one of the other methods described below.
+1. [GitHub][github]アカウントをお持ちでない場合、
+    [メール][contact]にてご連絡して下さい。
+    ですが、
+    以下の方法であればメールよりも早急に対応できる場合がありますので、そちらをお勧め致します。
 
-2.  If you have a [GitHub][github] account,
-    or are willing to [create one][github-join],
-    but do not know how to use Git,
-    you can report problems or suggest improvements by [creating an issue][issues].
-    This allows us to assign the item to someone
-    and to respond to it in a threaded discussion.
+2. [GitHub][github]アカウントをすでにお持ちである方・
+    またはアカウントを[新たに作る][github-join]気がある方で、
+    あまりGitに詳しくない・使い慣れていない方は、
+    質問・提案などを[新しいイシュー][new-issue]として開いて下さい。
+    イシューを開くことによって、コミュニティーから誰かをそのイシューに割り当て、
+    スレッド化したディスカッションとして質問・提案に応答させていただくことができます。
 
-3.  If you are comfortable with Git,
-    and would like to add or change material,
-    you can submit a pull request (PR).
-    Instructions for doing this are [included below](#using-github).
+3. Gitを使い慣れている方で、
+    既存の資料を変更、または追加したい方は、
+    プルリクエスト(Pull Request)にて変更点を提出して下さい。
+    プルリクエストを使った提出方法は、[下記に記載されています](#using-github)。
 
-## Where to Contribute
+## どこへ貢献するか
 
-1.  If you wish to change the template used for workshop websites,
-    please work in <https://github.com/swcarpentry/workshop-template>.
-    The home page of that repository explains how to set up workshop websites,
-    while the extra pages in <https://swcarpentry.github.io/workshop-template>
-    provide more background on our design choices.
+1.  このレッスンの内容を変更したい場合は、
+    <https://github.com/swcarpentry/r-novice-gapminder>から編集して下さい。
+    ウェブサイトはこちらから観覧いただけます：<https://swcarpentry.github.io/r-novice-gapminder>
 
-2.  If you wish to change CSS style files, tools,
-    or HTML boilerplate for lessons or workshops stored in `_includes` or `_layouts`,
-    please work in <https://github.com/swcarpentry/styles>.
+2.  模範レッスンの内容を変更したい場合は、
+    <https://github.com/carpentries/lesson-example>から編集して下さい。
+    このリポジトリは模範レッスンの内容を記載しており、
+    こちらから観覧できます：<https://carpentries.github.io/lesson-example>.
 
-## What to Contribute
+3.  ワークショップのウェブサイトに使われるテンプレートの内容を変更したい場合は、
+    <https://github.com/carpentries/workshop-template>から編集して下さい。
+    このリポジトリのホームページに、ワークショップに使うウェブサイトの設立方法が記載されており、
+    <https://carpentries.github.io/workshop-template>から
+    サイトの詳細なデザイン方針が観覧できます。
 
-There are many ways to contribute,
-from writing new exercises and improving existing ones
-to updating or filling in the documentation
-and submitting [bug reports][issues]
-about things that don't work, aren't clear, or are missing.
-If you are looking for ideas,
-please see [the list of issues for this repository][issues],
-or the issues for [Data Carpentry][dc-issues]
-and [Software Carpentry][swc-issues] projects.
+4.  `_includes`、または`_layouts`に保存されている、レッスンやワークショップのためのCSSファイル、ツール、
+    HTML boilerplateなどを編集したい場合は、
+    <https://github.com/carpentries/styles>から編集して下さい。
 
-Comments on issues and reviews of pull requests are just as welcome:
-we are smarter together than we are on our own.
-Reviews from novices and newcomers are particularly valuable:
-it's easy for people who have been using these lessons for a while
-to forget how impenetrable some of this material can be,
-so fresh eyes are always welcome.
+## 貢献していただきたい個所
 
-## What *Not* to Contribute
+新しい例を書く、すでにある例の改善、
+ドキュメントのアップデート、
+不明瞭な点、欠点、「動作に不具合がある」といった
+[バグの報告][new-issue]など、
+様々な方法で貢献していただくことができます。
+どういったイシューを開いたら良いかわからない場合は、
+[このリポジトリのイシュー][issues]、
+[Data Carpentryのイシュー][dc-issues]、
+もしくは[Software Carpentryのイシュー][swc-issues]を見てみて下さい。
 
-Our lessons already contain more material than we can cover in a typical workshop,
-so we are usually *not* looking for more concepts or tools to add to them.
-As a rule,
-if you want to introduce a new idea,
-you must (a) estimate how long it will take to teach
-and (b) explain what you would take out to make room for it.
-The first encourages contributors to be honest about requirements;
-the second, to think hard about priorities.
+すでにあるイシューへのコメントや、プルリクエストのレビューなども歓迎いたします。
+皆さんで協力したほうが、良い結果につながります。
+また、新しく加入された方の意見やレビューなどは特に重要視しています。
+レッスンの資料を幾度となく見てきた方は特に見落としがちなのですが、
+私達が提供している資料・コンテンツは、初めて資料を見る方などには、理解するのに時間が掛かる場合があるので、
+通常とは違う視点からの意見は大変貴重なのです。
 
-We are also not looking for exercises or other material that only run on one platform.
-Our workshops typically contain a mixture of Windows, macOS, and Linux users;
-in order to be usable,
-our lessons must run equally well on all three.
+## 貢献していただきたくない個所
 
-## Using GitHub
+現在、通常のワークショップの時間内ではカバーしきれないほどの内容量がレッスンの資料に含まれています。
+ですので、新たにレッスンに含められる項目やツールなどは求めておりません。
+どうしても新しい内容を入れたい場合は、
+(a)新しい内容を教えるために掛かるおおよその時間、
+(b)新しい内容を入れる代わりにどの内容を取り出すか、
+そして、取り出す理由をご説明下さい。
+最初の点は、貢献する方々に可能かどうかを見極めていただくためです。
+二つ目の点は、どちらの内容を有線するべきかを考えていただくためです。
 
-If you choose to contribute via GitHub,
-you may want to look at
-[How to Contribute to an Open Source Project on GitHub][how-contribute].
-In brief:
+上記に加え、一つのプラットホーム・OSでしか使用ができないなどといったプログラムのレッスン内容・資料などは求めておりません。
+私達が提供するワークショップでは、Windows、Mac OS X、Linuxなど、違ったOSを使用するユーザーが来ることがあります。
+そのため、新しいレッスンを作る際には、
+先述の三つのOSに対応可能である必要があります。
 
-1.  The published copy of the lesson is in the `gh-pages` branch of the repository
-    (so that GitHub will regenerate it automatically).
-    Please create all branches from that,
-    and merge the [master repository][repo]'s `gh-pages` branch into your `gh-pages` branch
-    before starting work.
-    Please do *not* work directly in your `gh-pages` branch,
-    since that will make it difficult for you to work on other contributions.
+## GitHubの使い方
 
-2.  We use [GitHub flow][github-flow] to manage changes:
-    1.  Create a new branch in your desktop copy of this repository for each significant change.
-    2.  Commit the change in that branch.
-    3.  Push that branch to your fork of this repository on GitHub.
-    4.  Submit a pull request from that branch to the [master repository][repo].
-    5.  If you receive feedback,
-        make changes on your desktop and push to your branch on GitHub:
-        the pull request will update automatically.
+GitHubから資料を提供したい場合は、
+[GitHubでオープンソース・プロジェクトに貢献する方法][how-contribute]
+を参照して下さい。
+簡潔にまとめると：
 
-Each lesson has two maintainers who review issues and pull requests
-or encourage others to do so.
-The maintainers are community volunteers,
-and have final say over what gets merged into the lesson.
+1.  現在公開されているレッスン内容はリポジトリの`gh-pages`というブランチに保存されています
+    (これはGitHubが自動的に変更点を公開させるためです)。
+    そのため、全てのブランチは`gh-pages`から分岐させ、
+    オリジナルの[リポジトリ][repo]の`gh-pages`を自身が分岐した`gh-pages`のブランチにマージ・合流させてから、
+    内容を変更してください。
+    他の内容・個所へ貢献することが難しくなるため、
+    *オリジナルの`gh-pages`から直接内容を変更することはお控え下さい。*
 
-## Other Resources
+2.  私達は[GitHub flow][github-flow]を使って変更点などを管理しています：
+    1.  自身が持っているオリジナルのリポジトリのコピー(フォーク)に新しいブランチを作り、そのブランチで内容を変更します。
+    2.  作ったブランチ内で変更点をコミットします。
+    3.  そのブランチをGitHubのフォークにプッシュします。
+    4.  自身のフォークからオリジナルの[リポジトリ][repo]へプルリクエストを提出します。
+    5.  頂いたコメントやレビューからの提案で、更に内容を変更する場合は、
+        自分のブランチで内容を変更し、GitHubのフォークにプッシュして下さい：
+        自動的にプルリクエストの内容がアップデートされます。
 
-General discussion of [Software Carpentry][swc-site] and [Data Carpentry][dc-site]
-happens on the [discussion mailing list][discuss-list],
-which everyone is welcome to join.
-You can also [reach us by email][contact].
+全てのレッスンには二人のメインテイナーがおり、彼・彼女らがイシューやプルリクエストを管理・見直す、
+もしくはその他のメンバーに、一緒に見直すように声をかけます。
+メインテイナー達はコミュニティーのボランティアですので、
+最終的に何を変更するかの決定権は、メインテイナーに委ねられています。
 
-[contact]: mailto:admin@software-carpentry.org
+## その他の資料
+
+[Software Carpentry][swc-site]と[Data Carpentry][dc-site]についての一般的なディスカッションは、
+[ディスカッション用のメーリングリスト][discuss-list]で行われ、
+どなたでも参加できます。
+また、[メール][contact]からでもご連絡いただけます。
+
+[contact]: mailto:team@carpentries.org
 [dc-issues]: https://github.com/issues?q=user%3Adatacarpentry
 [dc-lessons]: http://datacarpentry.org/lessons/
 [dc-site]: http://datacarpentry.org/
-[discuss-list]: http://lists.software-carpentry.org/listinfo/discuss
-[github]: http://github.com
+[discuss-list]: https://carpentries.topicbox.com/groups/discuss
+[github]: https://github.com
 [github-flow]: https://guides.github.com/introduction/flow/
 [github-join]: https://github.com/join
 [how-contribute]: https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github
-[issues]: https://github.com/swcarpentry/workshop-template/issues/
-[repo]: https://github.com/swcarpentry/workshop-template/
+[new-issue]: https://github.com/swcarpentry/r-novice-gapminder/issues/new
+[issues]: https://github.com/swcarpentry/r-novice-gapminder/issues/
+[repo]: https://github.com/swcarpentry/r-novice-gapminder/
 [swc-issues]: https://github.com/issues?q=user%3Aswcarpentry
-[swc-lessons]: http://software-carpentry.org/lessons/
-[swc-site]: http://software-carpentry.org/
+[swc-lessons]: https://software-carpentry.org/lessons/
+[swc-site]: https://software-carpentry.org/
+

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,8 +1,6 @@
 ---
 layout: page
 title: "ライセンス"
-root: .
-permalink: /ja/LICENSE/
 ---
 ## 教材
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,82 +1,85 @@
 ---
 layout: page
-title: "Licenses"
+title: "ライセンス"
+root: .
+permalink: /ja/LICENSE/
 ---
-## Instructional Material
+## 教材
 
-All Software Carpentry, Data Carpentry, and Library Carpentry instructional material is
-made available under the [Creative Commons Attribution
-license][cc-by-human]. The following is a human-readable summary of
-(and not a substitute for) the [full legal text of the CC BY 4.0
-license][cc-by-legal].
+ソフトウェアカーペントリーとData Carpentryに関する全ての教材は
+[クリエイティブ・コモンズ 表示ライセンス](https://creativecommons.org/licenses/by/4.0/deed.ja)
+の下で利用可能です。以下は、
+[表示4.0 国際(CC BY 4.0)ライセンスの完全な法的テキスト](https://creativecommons.org/licenses/by/4.0/legalcode.ja)の
+人が読んでわかりやすいようにした要約です。(ライセンスの代わりになるものではありません。）
 
-You are free:
+あなたは以下の条件に従う限り、自由に：
 
-* to **Share**---copy and redistribute the material in any medium or format
-* to **Adapt**---remix, transform, and build upon the material
+* **共有**---どのようなメディアやフォーマットでも資料を複製したり、再配布できます
+* **翻案**---マテリアルをリミックスしたり、改変したり、別の作品のベースにしたりできます
 
-for any purpose, even commercially.
 
-The licensor cannot revoke these freedoms as long as you follow the
-license terms.
+営利目的も含め、どのような目的でも。
 
-Under the following terms:
+あなたがライセンスの条件に従っている限り、許諾者がこれらの自由を
+取り消すことはできません。
 
-* **Attribution**---You must give appropriate credit (mentioning that
-  your work is derived from work that is Copyright © Software
-  Carpentry and, where practical, linking to
-  http://software-carpentry.org/), provide a [link to the
-  license][cc-by-human], and indicate if changes were made. You may do
-  so in any reasonable manner, but not in any way that suggests the
-  licensor endorses you or your use.
+あなたの従うべき条件は以下の通りです：
 
-**No additional restrictions**---You may not apply legal terms or
-technological measures that legally restrict others from doing
-anything the license permits.  With the understanding that:
+* **表示**---あなたは 適切なクレジットを表示し (あなたの作品が
+  ソフトウェアカーペントリーの著作物 (Software Carpentry©) から派生していることを記載して、
+  そして適切な場合は[http://software-carpentry.org](http://software-carpentry.org)へのリンクを表示), 
+  [ライセンスへのリンク](https://creativecommons.org/licenses/by/4.0/deed.ja)を
+  提供し、変更があったらその旨を示さなければなりません。
+  これらは合理的であればどのような方法で行っても構いませんが、
+  許諾者があなたやあなたの利用行為を支持していると示唆するような方法は除きます。
 
-Notices:
+**追加的な制約は課せません**---あなたは、このライセンスが他の者に
+許諾することを法的に制限するようないかなる法的規定も技術的手段も
+適用してはなりません：
 
-* You do not have to comply with the license for elements of the
-  material in the public domain or where your use is permitted by an
-  applicable exception or limitation.
-* No warranties are given. The license may not give you all of the
-  permissions necessary for your intended use. For example, other
-  rights such as publicity, privacy, or moral rights may limit how you
-  use the material.
+ご注意：
 
-## Software
+* あなたは、資料の中でパブリック・ドメインに属している部分に関して、
+  あるいはあなたの利用が著作権法上の権利制限規定にもとづく場合には、
+  ライセンスの規定に従う必要はありません。.
+* 保証は提供されていません。ライセンスはあなたの利用に
+  必要な全ての許諾を与えないかも知れません。例えば、パブリシティ権、
+  肖像権、人格権 などの他の諸権利はあなたがどのように資料を利用するかを
+制限することがあります。
 
-Except where otherwise noted, the example programs and other software
-provided by Software Carpentry and Data Carpentry are made available under the
-[OSI][osi]-approved
-[MIT license][mit-license].
+## ソフトウェア
 
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
+特に記載がある場合を除いて、ソフトウェアカーペントリーおよびデータカーペントリーが
+提供しているサンプルプログラムやソフトウェアは、
+[OSI][osi]が承認した
+[MITライセンス](https://ja.osdn.net/projects/opensource/wiki/licenses%2FMIT_license)の下で利用可能です。
 
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
+以下に定める条件に従い、本ソフトウェアおよび関連文書のファイル
+（以下「ソフトウェア」）の複製を取得するすべての人に対し、ソフトウェアを
+無制限に扱うことを無償で許可します。これには、ソフトウェアの複製を使用、
+複写、変更、結合、掲載、頒布、サブライセンス、および/または販売する権利、
+およびソフトウェアを提供する相手に同じことを許可する権利も無制限に含まれます。
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+上記の著作権表示および本許諾表示を、ソフトウェアのすべての複製または
+重要な部分に記載するものとします。
 
-## Trademark
+ソフトウェアは「現状のまま」で、明示であるか暗黙であるかを問わず、
+何らの保証もなく提供されます。ここでいう保証とは、商品性、
+特定の目的への適合性、および権利非侵害についての保証も含みますが、
+それに限定されるものではありません。 作者または著作権者は、契約行為、
+不法行為、またはそれ以外であろうと、ソフトウェアに起因または関連し、
+あるいはソフトウェアの使用またはその他の扱いによって生じる一切の請求、
+損害、その他の義務について何らの責任も負わないものとします。
 
-"Software Carpentry" and "Data Carpentry" and their respective logos
-are registered trademarks of [Community Initiatives][CI].
+## 商標
+
+「Software Carpentry」と「Data Carpentry」およびそれぞれのロゴは[Community
+Initiatives][CI]における登録商標または商標です。
 
 [cc-by-human]: https://creativecommons.org/licenses/by/4.0/
 [cc-by-legal]: https://creativecommons.org/licenses/by/4.0/legalcode
 [mit-license]: https://opensource.org/licenses/mit-license.html
 [ci]: http://communityin.org/
 [osi]: https://opensource.org
+[osg]: https://opensource.jp
+

--- a/index.md
+++ b/index.md
@@ -152,7 +152,7 @@ This block displays the date and links to Google Calendar.
 {% endcomment %}
 {% if page.humandate %}
 <p id="when">
-  <strong>When:</strong>
+  <strong>何日:</strong>
   {{page.humandate}}.
   {% include workshop_calendar.html %}
 </p>

--- a/index.md
+++ b/index.md
@@ -152,7 +152,7 @@ This block displays the date and links to Google Calendar.
 {% endcomment %}
 {% if page.humandate %}
 <p id="when">
-  <strong>何日:</strong>
+  <strong>日程:</strong>
   {{page.humandate}}.
   {% include workshop_calendar.html %}
 </p>


### PR DESCRIPTION
These files are based on translations of the exact same content in the [Japanese R lessons](https://github.com/swcarpentry-ja/r-novice-gapminder/)