### PR TITLE
Direct to Japanese version of Code of Conduct

### DIFF
--- a/_includes/links.md
+++ b/_includes/links.md
@@ -3,7 +3,7 @@
 [cc-by-legal]: https://creativecommons.org/licenses/by/4.0/legalcode
 [ci]: http://communityin.org/
 [coc-reporting]: https://docs.carpentries.org/topic_folders/policies/incident-reporting.html
-[coc]: https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html
+[coc]: https://carpentries-coc.readthedocs.io/ja/latest/topic_folders/policies/code-of-conduct.html
 [concept-maps]: https://carpentries.github.io/instructor-training/05-memory/
 [contrib-covenant]: https://contributor-covenant.org/
 [contributing]: {{ repo_url }}/blob/{{ source_branch }}/CONTRIBUTING.md


### PR DESCRIPTION
Redirects Code of Conduct link to Japanese version on partial translation of Code of Conduct: [https://carpentries-coc.readthedocs.io/ja/latest/](https://carpentries-coc.readthedocs.io/ja/latest/)

The main Code of Conduct has been translated and is hosted on GitHub here:
https://github.com/swcarpentry-ja/carpentries-coc/

Pull requests to edit this file will update the other pages in the partial translation. Ideally, enforcement and incident reporting should also be clear to workshop participants if we have time to translate more sections.
https://github.com/swcarpentry-ja/carpentries-coc/blob/main/po/ja.po#L798-L1405