### PR TITLE
link to English page

### DIFF
--- a/index.md
+++ b/index.md
@@ -78,6 +78,8 @@ displayed if the 'eventbrite' field in the header is not set.
 
 <h2 id="general">基本情報</h2>
 
+<a href="//swcarpentry-ja.github.io/2021-04-02-todai-online-en/">（English site is here）</a>.
+
 {% comment %}
 INTRODUCTION
 


### PR DESCRIPTION
Adds a link to the English page from Japanese. Reciprocal changes here: https://github.com/swcarpentry-ja/2021-04-02-todai-online-en/pull/2

Corresponding changes to template: https://github.com/swcarpentry-ja/workshop-template-ja/commit/36343adefeaa797a966e79c3a8b6750ffc7487c7